### PR TITLE
Fix attribute error and use current working directory for output

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -97,7 +97,7 @@ def main():
             continue
 
         if slash != -1:
-            title = title.text.replace('/', ' ')
+            title = title.replace('/', ' ')
             directory = url[:slash]
             filename = url[slash+1:]
             directory_list[directory] = True

--- a/convert.py
+++ b/convert.py
@@ -60,7 +60,7 @@ def main():
             print(f"Creating output directory {output_path}\n\n")
             os.makedirs(output_path)
     else:
-        output_path = ''
+        output_path = os.getcwd()
 
     format = args.format
     add_meta = args.fm or (not args.fm and format == 'gfm')


### PR DESCRIPTION
This PR fixes an attribute error with the string replace operation on page titles and uses the current working directory for output if no output path is provided by the user.